### PR TITLE
Add reference constraint support for sql server only

### DIFF
--- a/EntityFramework.Exceptions.Common/ExceptionProcessorStateManager.cs
+++ b/EntityFramework.Exceptions.Common/ExceptionProcessorStateManager.cs
@@ -15,7 +15,8 @@ namespace EntityFramework.Exceptions.Common
             UniqueConstraint,
             CannotInsertNull,
             MaxLength,
-            NumericOverflow
+            NumericOverflow,
+            ReferenceConstraint
         }
 
         private static readonly Dictionary<DatabaseError, Func<DbUpdateException, Exception>> ExceptionMapping = new Dictionary<DatabaseError, Func<DbUpdateException, Exception>>
@@ -23,7 +24,8 @@ namespace EntityFramework.Exceptions.Common
             {DatabaseError.MaxLength, exception => new MaxLengthExceededException("Maximum length exceeded", exception.InnerException) },
             {DatabaseError.UniqueConstraint, exception => new UniqueConstraintException("Unique constraint violation", exception.InnerException) },
             {DatabaseError.CannotInsertNull, exception => new CannotInsertNullException("Cannot insert null", exception.InnerException) },
-            {DatabaseError.NumericOverflow, exception => new NumericOverflowException("Numeric overflow", exception.InnerException) }
+            {DatabaseError.NumericOverflow, exception => new NumericOverflowException("Numeric overflow", exception.InnerException) },
+            {DatabaseError.ReferenceConstraint, exception => new ReferenceConstraintException("Reference constraint violation", exception.InnerException) }
         };
 
         protected ExceptionProcessorStateManager(StateManagerDependencies dependencies) : base(dependencies)

--- a/EntityFramework.Exceptions.Common/Exceptions.cs
+++ b/EntityFramework.Exceptions.Common/Exceptions.cs
@@ -64,4 +64,19 @@ namespace EntityFramework.Exceptions.Common
         {
         }
     }
+
+    public class ReferenceConstraintException : DbUpdateException
+    {
+        public ReferenceConstraintException(string message, Exception innerException) : base(message, innerException)
+        {
+        }
+
+        public ReferenceConstraintException(string message, IReadOnlyList<IUpdateEntry> entries) : base(message, entries)
+        {
+        }
+
+        public ReferenceConstraintException(string message, Exception innerException, IReadOnlyList<IUpdateEntry> entries) : base(message, innerException, entries)
+        {
+        }
+    }
 }

--- a/EntityFramework.Exceptions.SqlServer/SqlServerExceptionProcessorStateManager.cs
+++ b/EntityFramework.Exceptions.SqlServer/SqlServerExceptionProcessorStateManager.cs
@@ -11,6 +11,7 @@ namespace EntityFramework.Exceptions.SqlServer
         {
         }
 
+        private const int ReferenceConstraint = 547;
         private const int CannotInsertNull = 515;
         private const int CannotInsertDuplicateKeyUniqueIndex = 2601;
         private const int CannotInsertDuplicateKeyUniqueConstraint = 2627;
@@ -21,6 +22,8 @@ namespace EntityFramework.Exceptions.SqlServer
         {
             switch (dbException.Number)
             {
+                case ReferenceConstraint:
+                    return DatabaseError.ReferenceConstraint;
                 case CannotInsertNull:
                     return DatabaseError.CannotInsertNull;
                 case CannotInsertDuplicateKeyUniqueIndex:


### PR DESCRIPTION
I want to add support for error 547 in sql server which is a reference constraint error, e.g. 
Server: Msg 547, Level 16, State 1, Line 1
DELETE statement conflicted with COLUMN REFERENCE 
constraint Constraint Name.  The conflict occurred in
database Database Name, table Table Name, column
Column Name.
The statement has been terminated.

This could also apply to other kind of constraint like CHECK CONSTRAINT, not only limited to FOREIGN KEY CONSTRAINTS.
