### PR TITLE
Add support for Sqlite Exceptions

### DIFF
--- a/EntityFramework.Exceptions.Sqlite/EntityFramework.Exceptions.Sqlite.csproj
+++ b/EntityFramework.Exceptions.Sqlite/EntityFramework.Exceptions.Sqlite.csproj
@@ -1,0 +1,41 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <Version>3.1.1</Version>
+    <Authors>Giorgi Dalakishvili</Authors>
+    <Copyright>Copyright (c) 2018 Giorgi Dalakishvili</Copyright>
+    <PackageTags>EntityFramework EF MySql EntityFrameworkCore entity-framework-core EFCore Data Database</PackageTags>
+    <PackageLicenseUrl>https://github.com/Giorgi/EntityFramework.Exceptions/blob/master/License.md</PackageLicenseUrl>
+    <PackageProjectUrl>https://github.com/Giorgi/EntityFramework.Exceptions</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/Giorgi/EntityFramework.Exceptions</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
+    <PackageReleaseNotes>
+      Added support for Entity Framework Core 3
+Added support for ReferenceConstraintException
+    </PackageReleaseNotes>
+    <PackageIconUrl>https://raw.githubusercontent.com/Giorgi/EntityFramework.Exceptions/master/Icon.png</PackageIconUrl>
+    <Description>Handle database errors easily when working with Entity Framework Core. Catch specific exceptions such as UniqueConstraintException, CannotInsertNullException, MaxLengthExceededException, NumericOverflowException instead of generic DbUpdateException</Description>
+    <PackageId>EntityFrameworkCore.Exceptions.Sqlite</PackageId>
+    <AssemblyVersion>3.1.1.0</AssemblyVersion>
+    <FileVersion>3.1.1.0</FileVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Data.SQLite" Version="3.1.3" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="3.1.1" />
+    <PackageReference Include="MySql.Data" Version="8.0.13" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\EntityFramework.Exceptions.Common\EntityFramework.Exceptions.Common.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/EntityFramework.Exceptions.Sqlite/SqliteExceptionProcessorStateManager.cs
+++ b/EntityFramework.Exceptions.Sqlite/SqliteExceptionProcessorStateManager.cs
@@ -1,0 +1,54 @@
+﻿using EntityFramework.Exceptions.Common;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
+using static SQLitePCL.raw;
+
+namespace EntityFramework.Exceptions.Sqlite
+{
+    class SqliteExceptionProcessorStateManager : ExceptionProcessorStateManager<SqliteException>
+    {
+        public SqliteExceptionProcessorStateManager(StateManagerDependencies dependencies) : base(dependencies)
+        {
+        }
+
+        protected override DatabaseError? GetDatabaseError(SqliteException dbException)
+        {
+            if (dbException.SqliteErrorCode == SQLITE_TOOBIG)
+            {
+                return DatabaseError.MaxLength;
+            }
+
+            if (dbException.SqliteErrorCode == SQLITE_CONSTRAINT)
+            {
+                switch (dbException.SqliteExtendedErrorCode)
+                {
+                    case SQLITE_CONSTRAINT_NOTNULL:
+                        return DatabaseError.CannotInsertNull;
+                    case SQLITE_CONSTRAINT_UNIQUE:
+                        return DatabaseError.UniqueConstraint;
+                    case SQLITE_CONSTRAINT_FOREIGNKEY:
+                        return DatabaseError.ReferenceConstraint;
+                }
+            }
+
+            return null;
+        }
+    }
+
+    public static class ExceptionProcessorExtensions
+    {
+        public static DbContextOptionsBuilder UseExceptionProcessor(this DbContextOptionsBuilder self)
+        {
+            self.ReplaceService<IStateManager, SqliteExceptionProcessorStateManager>();
+            return self;
+        }
+
+        public static DbContextOptionsBuilder<TContext> UseExceptionProcessor<TContext>(
+            this DbContextOptionsBuilder<TContext> self) where TContext : DbContext
+        {
+            self.ReplaceService<IStateManager, SqliteExceptionProcessorStateManager>();
+            return self;
+        }
+    }
+}

--- a/EntityFramework.Exceptions.Tests/EntityFramework.Exceptions.Tests.csproj
+++ b/EntityFramework.Exceptions.Tests/EntityFramework.Exceptions.Tests.csproj
@@ -7,7 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.3" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.1" />
     <PackageReference Include="MySql.Data.EntityFrameworkCore" Version="8.0.19" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="3.1.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
@@ -20,6 +20,7 @@
   <ItemGroup>
     <ProjectReference Include="..\EntityFramework.Exceptions.MySQL\EntityFramework.Exceptions.MySQL.csproj" />
     <ProjectReference Include="..\EntityFramework.Exceptions.PostgreSQL\EntityFramework.Exceptions.PostgreSQL.csproj" />
+    <ProjectReference Include="..\EntityFramework.Exceptions.Sqlite\EntityFramework.Exceptions.Sqlite.csproj" />
     <ProjectReference Include="..\EntityFramework.Exceptions.SqlServer\EntityFramework.Exceptions.SqlServer.csproj" />
   </ItemGroup>
 

--- a/EntityFramework.Exceptions.Tests/SqliteTests.cs
+++ b/EntityFramework.Exceptions.Tests/SqliteTests.cs
@@ -1,0 +1,60 @@
+﻿using EntityFramework.Exceptions.Common;
+using EntityFramework.Exceptions.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using System;
+using Xunit;
+
+namespace EntityFramework.Exceptions.Tests
+{
+    public class SqliteTests : IClassFixture<SqliteDemoContextFixture>, IDisposable
+    {
+        private readonly DemoContextFixture fixture;
+
+        public SqliteTests(SqliteDemoContextFixture fixture)
+        {
+            this.fixture = fixture;
+        }
+
+        [Fact]
+        public void UniqueColumnViolationThrowsUniqueConstraintException()
+        {
+            fixture.Context.Products.Add(new Product { Name = "GD" });
+            fixture.Context.Products.Add(new Product { Name = "GD" });
+
+            Assert.Throws<UniqueConstraintException>(() => fixture.Context.SaveChanges());
+        }
+
+        [Fact]
+        public void RequiredColumnViolationThrowsCannotInsertNullException()
+        {
+            fixture.Context.Products.Add(new Product());
+
+            Assert.Throws<CannotInsertNullException>(() => fixture.Context.SaveChanges());
+        }
+
+        [Fact]
+        public void ReferenceViolationThrowsReferenceConstraintException()
+        {
+            fixture.Context.ProductSales.Add(new ProductSale { Price = 3.14m});
+
+            Assert.Throws<ReferenceConstraintException>(() => fixture.Context.SaveChanges());
+        }
+
+        public void Dispose()
+        {
+            foreach (var entityEntry in fixture.Context.ChangeTracker.Entries())
+            {
+                entityEntry.State = EntityState.Detached;
+            }
+        }
+    }
+
+    public class SqliteDemoContextFixture : DemoContextFixture
+    {
+        protected override DbContextOptionsBuilder<DemoContext> BuildOptions(DbContextOptionsBuilder<DemoContext> builder, IConfigurationRoot configuration)
+        {
+            return builder.UseSqlite(configuration.GetConnectionString("Sqlite")).UseExceptionProcessor();
+        }
+    }
+}

--- a/EntityFramework.Exceptions.Tests/appsettings.Appveyor.json
+++ b/EntityFramework.Exceptions.Tests/appsettings.Appveyor.json
@@ -2,6 +2,7 @@
   "ConnectionStrings": {
     "SqlServer": "Server=(local)\\SQL2017;Database=EntityFramework.Exceptions.Test;User ID=sa;Password=Password12!",
     "PostgreSQL": "Server=127.0.0.1;Port=5432;Database=EntityFramework.Exceptions.Test;User Id=postgres;Password=Password12!;",
-    "MySQL": "Server=127.0.0.1;Port=3306;Database=EntityFramework.Exceptions.Test;User Id=root;Password=Password12!;"
+    "MySQL": "Server=127.0.0.1;Port=3306;Database=EntityFramework.Exceptions.Test;User Id=root;Password=Password12!;",
+    "Sqlite": "Data Source=./sqlite_test.db;"
   }
 }

--- a/EntityFramework.Exceptions.Tests/appsettings.json
+++ b/EntityFramework.Exceptions.Tests/appsettings.json
@@ -4,6 +4,7 @@
   "ConnectionStrings": {
     "SqlServer": "",
     "PostgreSQL": "",
-    "MySQL": ""
+    "MySQL": "",
+    "Sqlite": "Data Source=./sqlite_test.db;"
   }
 }

--- a/EntityFramework.Exceptions.sln
+++ b/EntityFramework.Exceptions.sln
@@ -13,6 +13,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "EntityFramework.Exceptions.
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "EntityFramework.Exceptions.Tests", "EntityFramework.Exceptions.Tests\EntityFramework.Exceptions.Tests.csproj", "{683A266C-5559-4453-A681-861EA68825BE}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EntityFramework.Exceptions.Sqlite", "EntityFramework.Exceptions.Sqlite\EntityFramework.Exceptions.Sqlite.csproj", "{A46DB793-7671-4919-9DE4-4E64ADEDB38E}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -39,6 +41,10 @@ Global
 		{683A266C-5559-4453-A681-861EA68825BE}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{683A266C-5559-4453-A681-861EA68825BE}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{683A266C-5559-4453-A681-861EA68825BE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A46DB793-7671-4919-9DE4-4E64ADEDB38E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A46DB793-7671-4919-9DE4-4E64ADEDB38E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A46DB793-7671-4919-9DE4-4E64ADEDB38E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A46DB793-7671-4919-9DE4-4E64ADEDB38E}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Note that SQLite does not impose any [length restrictions](https://www.sqlite.org/datatype3.html) so the MaxLength test doesn't make sense for this provider. Limiting to 15 chars won't throw an exception (other than SQLITE_TOOBIG). Thus, the test has not been implemented.

I also didn't manage to trigger any exception for numeric overflow. I guess that Sqlite doesn't handle them either. You can see all the error codes [here](https://sqlite.org/rescode.html#extrc).

Note that a check on `SQLITE_TOOBIG` (max length of a string/blob/... overflowed) is done, but without any test. This is because `SQLITE_MAX_LENGTH` is by default 1,000,000,000 bytes ([source](https://www.sqlite.org/limits.html)). This could be in theory set at runtime, for the test, but I didn't manage to find a quick way to do so and I don't think it's essential for the PR.

For testing, setting the connection string to `"Data Source=./sqlite_test.db;"` will create a database in the current directory with the name `sqlite_test.db`. I'm not sure if it's good for you and appveyor, let me know.

Fixes / Followup of #11 