### PR TITLE
Add tests for duplicate primary keys inserts

### DIFF
--- a/EntityFramework.Exceptions.Tests/DatabaseTests.cs
+++ b/EntityFramework.Exceptions.Tests/DatabaseTests.cs
@@ -15,7 +15,7 @@ namespace EntityFramework.Exceptions.Tests
             Context = GetNewContext();
         }
 
-        private DemoContext GetNewContext()
+        protected virtual DemoContext GetNewContext()
         {
             return new DemoContext(ContextOptions);
         }
@@ -35,11 +35,11 @@ namespace EntityFramework.Exceptions.Tests
             var product1 = new Product { Name = "PROD1", Id = 42 };
             var product2 = new Product { Name = "PROD2", Id = 42 };
 
-            var context1 = GetNewContext();
+            using var context1 = GetNewContext();
             context1.Products.Add(product1);
             context1.SaveChanges();
 
-            var context2 = GetNewContext();
+            using var context2 = GetNewContext();
             context2.Products.Add(product2);
             Assert.Throws<UniqueConstraintException>(() => context2.SaveChanges());
         }
@@ -57,11 +57,11 @@ namespace EntityFramework.Exceptions.Tests
             var item2 = new CompositeKeyItem
                 {ProductId = product.Id, ProductSaleId = productSale.Id};
 
-            var context1 = GetNewContext();
+            using var context1 = GetNewContext();
             context1.CompositeKeyItems.Add(item1);
             context1.SaveChanges();
 
-            var context2 = GetNewContext();
+            using var context2 = GetNewContext();
             context2.CompositeKeyItems.Add(item2);
             Assert.Throws<UniqueConstraintException>(() => context2.SaveChanges());
         }

--- a/EntityFramework.Exceptions.Tests/DatabaseTests.cs
+++ b/EntityFramework.Exceptions.Tests/DatabaseTests.cs
@@ -1,4 +1,4 @@
-﻿using EntityFramework.Exceptions.Common;
+using EntityFramework.Exceptions.Common;
 using Microsoft.EntityFrameworkCore;
 using Xunit;
 
@@ -7,10 +7,17 @@ namespace EntityFramework.Exceptions.Tests
     public abstract class DatabaseTests
     {
         internal DemoContext Context { get; }
+        internal DbContextOptions<DemoContext> ContextOptions { get; }
 
-        protected DatabaseTests(DemoContext context)
+        protected DatabaseTests(DbContextOptions<DemoContext> contextOptions)
         {
-            Context = context;
+            ContextOptions = contextOptions;
+            Context = GetNewContext();
+        }
+
+        private DemoContext GetNewContext()
+        {
+            return new DemoContext(ContextOptions);
         }
 
         [Fact]
@@ -20,6 +27,43 @@ namespace EntityFramework.Exceptions.Tests
             Context.Products.Add(new Product { Name = "GD" });
 
             Assert.Throws<UniqueConstraintException>(() => Context.SaveChanges());
+        }
+
+        [Fact]
+        public virtual void PrimaryKeyViolationThrowsUniqueConstraintException()
+        {
+            var product1 = new Product { Name = "PROD1", Id = 42 };
+            var product2 = new Product { Name = "PROD2", Id = 42 };
+
+            var context1 = GetNewContext();
+            context1.Products.Add(product1);
+            context1.SaveChanges();
+
+            var context2 = GetNewContext();
+            context2.Products.Add(product2);
+            Assert.Throws<UniqueConstraintException>(() => context2.SaveChanges());
+        }
+
+        [Fact]
+        public virtual void PrimaryCompositeKeyViolationThrowsUniqueConstraintException()
+        {
+            var product = new Product { Name = "GD" };
+            Context.Products.Add(product);
+            var productSale = new ProductSale { Price = 42, Product = product };
+            Context.ProductSales.Add(productSale);
+
+            var item1 = new CompositeKeyItem
+                {ProductId = product.Id, ProductSaleId = productSale.Id};
+            var item2 = new CompositeKeyItem
+                {ProductId = product.Id, ProductSaleId = productSale.Id};
+
+            var context1 = GetNewContext();
+            context1.CompositeKeyItems.Add(item1);
+            context1.SaveChanges();
+
+            var context2 = GetNewContext();
+            context2.CompositeKeyItems.Add(item2);
+            Assert.Throws<UniqueConstraintException>(() => context2.SaveChanges());
         }
 
         [Fact]

--- a/EntityFramework.Exceptions.Tests/DemoContext.cs
+++ b/EntityFramework.Exceptions.Tests/DemoContext.cs
@@ -11,12 +11,15 @@ namespace EntityFramework.Exceptions.Tests
 
         public DbSet<Product> Products { get; set; }
         public DbSet<ProductSale> ProductSales { get; set; }
-        
+
+        public DbSet<CompositeKeyItem> CompositeKeyItems { get; set; }
+
         protected override void OnModelCreating(ModelBuilder builder)
         {
             builder.Entity<Product>().HasIndex(u => u.Name).IsUnique();
             builder.Entity<Product>().Property(b => b.Name).IsRequired().HasMaxLength(15);
             builder.Entity<ProductSale>().Property(b => b.Price).HasColumnType("decimal(5,2)").IsRequired();
+            builder.Entity<CompositeKeyItem>().HasKey(x => new {x.ProductId, x.ProductSaleId});
         }
     }
 
@@ -34,5 +37,11 @@ namespace EntityFramework.Exceptions.Tests
 
         public int ProductId { get; set; }
         public Product Product { get; set; }
+    }
+
+    public class CompositeKeyItem
+    {
+        public int ProductId { get; set; }
+        public int ProductSaleId { get; set; }
     }
 }

--- a/EntityFramework.Exceptions.Tests/DemoContextFixture.cs
+++ b/EntityFramework.Exceptions.Tests/DemoContextFixture.cs
@@ -7,6 +7,7 @@ namespace EntityFramework.Exceptions.Tests
     public abstract class DemoContextFixture : IDisposable
     {
         internal DemoContext Context { get; }
+        internal DbContextOptions<DemoContext> ContextOptions { get; }
 
         protected DemoContextFixture()
         {
@@ -15,8 +16,10 @@ namespace EntityFramework.Exceptions.Tests
             var configuration = new ConfigurationBuilder().AddJsonFile($"appsettings.{environment}.json", optional: true).Build();
             
             var builder = BuildOptions(new DbContextOptionsBuilder<DemoContext>(), configuration);
+            ContextOptions = builder.Options;
 
-            Context = new DemoContext(builder.Options);
+            Context = new DemoContext(ContextOptions);
+            Context.Database.EnsureDeleted();
             Context.Database.EnsureCreated();
         }
 

--- a/EntityFramework.Exceptions.Tests/MySqlServerTests.cs
+++ b/EntityFramework.Exceptions.Tests/MySqlServerTests.cs
@@ -8,12 +8,22 @@ namespace EntityFramework.Exceptions.Tests
 {
     public class MySQLServerTests : DatabaseTests, IClassFixture<MySQLDemoContextFixture>, IDisposable
     {
-        public MySQLServerTests(MySQLDemoContextFixture fixture) : base(fixture.Context)
+        public MySQLServerTests(MySQLDemoContextFixture fixture) : base(fixture.ContextOptions)
         {
         }
 
         [Fact(Skip = "Skipping until EF Core 3.1 is supported by MySQL")]
         public override void UniqueColumnViolationThrowsUniqueConstraintException()
+        {
+        }
+
+        [Fact(Skip = "Skipping until EF Core 3.1 is supported by MySQL")]
+        public override void PrimaryKeyViolationThrowsUniqueConstraintException()
+        {
+        }
+
+        [Fact(Skip = "Skipping until EF Core 3.1 is supported by MySQL")]
+        public override void PrimaryCompositeKeyViolationThrowsUniqueConstraintException()
         {
         }
 

--- a/EntityFramework.Exceptions.Tests/PostgreSQLTests.cs
+++ b/EntityFramework.Exceptions.Tests/PostgreSQLTests.cs
@@ -8,7 +8,7 @@ namespace EntityFramework.Exceptions.Tests
 {
     public class PostgreSQLTests : DatabaseTests, IClassFixture<PostgreSQLDemoContextFixture>, IDisposable
     {
-        public PostgreSQLTests(PostgreSQLDemoContextFixture fixture): base(fixture.Context)
+        public PostgreSQLTests(PostgreSQLDemoContextFixture fixture): base(fixture.ContextOptions)
         {
         }
     }

--- a/EntityFramework.Exceptions.Tests/SqlServerTests.cs
+++ b/EntityFramework.Exceptions.Tests/SqlServerTests.cs
@@ -8,7 +8,12 @@ namespace EntityFramework.Exceptions.Tests
 {
     public class SqlServerTests : DatabaseTests, IClassFixture<SqlServerDemoContextFixture>, IDisposable
     {
-        public SqlServerTests(SqlServerDemoContextFixture fixture) : base(fixture.Context)
+        public SqlServerTests(SqlServerDemoContextFixture fixture) : base(fixture.ContextOptions)
+        {
+        }
+
+        [Fact(Skip = "Skipping as IDENTITY_INSERT must be set to ON to write IDs directly in db")]
+        public override void PrimaryKeyViolationThrowsUniqueConstraintException()
         {
         }
     }

--- a/EntityFramework.Exceptions.Tests/SqlServerTests.cs
+++ b/EntityFramework.Exceptions.Tests/SqlServerTests.cs
@@ -6,21 +6,62 @@ using Xunit;
 
 namespace EntityFramework.Exceptions.Tests
 {
+    internal sealed class DemoContextWithIdentityInsert : DemoContext
+    {
+        private readonly string _columnName;
+
+        public DemoContextWithIdentityInsert(DbContextOptions options, string columnName) : base(options)
+        {
+            _columnName = columnName;
+            // need to open the connection for identity insert to work, cf: https://stackoverflow.com/a/58847404
+            Database.OpenConnection();
+            SetIdentityInsert(true);
+        }
+
+        public override void Dispose()
+        {
+            SetIdentityInsert(false);
+            Database.CloseConnection();
+            base.Dispose();
+        }
+
+        private void SetIdentityInsert(bool enable)
+        {
+            var onOff = enable ? "ON" : "OFF";
+            Database.ExecuteSqlRaw($"SET IDENTITY_INSERT {_columnName} {onOff}");
+        }
+    }
+
     public class SqlServerTests : DatabaseTests, IClassFixture<SqlServerDemoContextFixture>, IDisposable
     {
+        private bool _enableIdentityInsert;
+        private string _identityInsertTableName;
+
         public SqlServerTests(SqlServerDemoContextFixture fixture) : base(fixture.ContextOptions)
         {
         }
 
-        [Fact(Skip = "Skipping as IDENTITY_INSERT must be set to ON to write IDs directly in db")]
+        protected override DemoContext GetNewContext()
+        {
+            return _enableIdentityInsert
+                ? new DemoContextWithIdentityInsert(base.ContextOptions, _identityInsertTableName)
+                : base.GetNewContext();
+        }
+
         public override void PrimaryKeyViolationThrowsUniqueConstraintException()
         {
+            // IDENTITY_INSERT must be set to ON to write IDs directly in db
+            _enableIdentityInsert = true;
+            _identityInsertTableName = nameof(DemoContext.Products);
+
+            base.PrimaryKeyViolationThrowsUniqueConstraintException();
         }
     }
 
     public class SqlServerDemoContextFixture : DemoContextFixture
     {
-        protected override DbContextOptionsBuilder<DemoContext> BuildOptions(DbContextOptionsBuilder<DemoContext> builder, IConfigurationRoot configuration)
+        protected override DbContextOptionsBuilder<DemoContext> BuildOptions(
+            DbContextOptionsBuilder<DemoContext> builder, IConfigurationRoot configuration)
         {
             return builder.UseSqlServer(configuration.GetConnectionString("SqlServer")).UseExceptionProcessor();
         }

--- a/EntityFramework.Exceptions.Tests/SqliteTests.cs
+++ b/EntityFramework.Exceptions.Tests/SqliteTests.cs
@@ -8,7 +8,7 @@ namespace EntityFramework.Exceptions.Tests
 {
     public class SqliteTests : DatabaseTests, IClassFixture<SqliteDemoContextFixture>, IDisposable
     {
-        public SqliteTests(SqliteDemoContextFixture fixture) : base(fixture.Context)
+        public SqliteTests(SqliteDemoContextFixture fixture) : base(fixture.ContextOptions)
         {
         }
 


### PR DESCRIPTION
* Add a simple test for adding two different products with the same ID
  Note: this is disabled for SqlServer as it would need
  IDENTITY_INSERT enabled.
* Add a test with a composite primary key for adding two different
  items with the same primary keys.
  This test works for all providers.
  Note: this test introduces a dummy entity, CompisiteKeyItem,
  referencing the IDs of Product and ProductSale

These two tests require to have two DbContext in the test. Thus, a new
method returning a new DbContext has been created and the constructors
modified to fit those needs.