### PR TITLE
Added ability to add ExceptionProcessorInterceptor to ServiceCollection

### DIFF
--- a/EntityFramework.Exceptions.MySQL.Pomelo/MySQL.Pomelo.csproj
+++ b/EntityFramework.Exceptions.MySQL.Pomelo/MySQL.Pomelo.csproj
@@ -28,4 +28,10 @@ Use this package if you use Pomelo.EntityFrameworkCore.MySql Entity Framework Co
   <ItemGroup>
     <PackageReference Update="Microsoft.SourceLink.GitHub" Version="1.1.1" />
   </ItemGroup>
+
+	<ItemGroup>
+		<AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+			<_Parameter1>$(SolutionName).Tests</_Parameter1>
+		</AssemblyAttribute>
+	</ItemGroup>
 </Project>

--- a/EntityFramework.Exceptions.MySQL/MySQL.csproj
+++ b/EntityFramework.Exceptions.MySQL/MySQL.csproj
@@ -14,4 +14,10 @@
   <ItemGroup>
     <PackageReference Update="Microsoft.SourceLink.GitHub" Version="1.1.1" />
   </ItemGroup>
+
+	<ItemGroup>
+		<AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+			<_Parameter1>$(SolutionName).Tests</_Parameter1>
+		</AssemblyAttribute>
+	</ItemGroup>
 </Project>

--- a/EntityFramework.Exceptions.MySQL/MySqlExceptionProcessorInterceptor.cs
+++ b/EntityFramework.Exceptions.MySQL/MySqlExceptionProcessorInterceptor.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using EntityFramework.Exceptions.Common;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.Extensions.DependencyInjection;
 
 #if POMELO
 using MySqlConnector;
@@ -36,6 +38,12 @@ class MySqlExceptionProcessorInterceptor : ExceptionProcessorInterceptor<MySqlEx
 
 public static class ExceptionProcessorExtensions
 {
+    public static IServiceCollection AddExceptionProcessor(this IServiceCollection services, ServiceLifetime serviceLifetime = ServiceLifetime.Scoped)
+    {
+        services.Add(ServiceDescriptor.Describe(typeof(IInterceptor), typeof(MySqlExceptionProcessorInterceptor), serviceLifetime));
+        return services;
+    }
+
     public static DbContextOptionsBuilder UseExceptionProcessor(this DbContextOptionsBuilder self)
     {
         return self.AddInterceptors(new MySqlExceptionProcessorInterceptor());

--- a/EntityFramework.Exceptions.Oracle/Oracle.csproj
+++ b/EntityFramework.Exceptions.Oracle/Oracle.csproj
@@ -14,4 +14,10 @@
   <ItemGroup>
     <PackageReference Update="Microsoft.SourceLink.GitHub" Version="1.1.1" />
   </ItemGroup>
+
+	<ItemGroup>
+		<AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+			<_Parameter1>$(SolutionName).Tests</_Parameter1>
+		</AssemblyAttribute>
+	</ItemGroup>
 </Project>

--- a/EntityFramework.Exceptions.Oracle/OracleExceptionProcessorInterceptor.cs
+++ b/EntityFramework.Exceptions.Oracle/OracleExceptionProcessorInterceptor.cs
@@ -1,5 +1,7 @@
 using EntityFramework.Exceptions.Common;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.Extensions.DependencyInjection;
 using Oracle.ManagedDataAccess.Client;
 
 namespace EntityFramework.Exceptions.Oracle;
@@ -30,6 +32,12 @@ class OracleExceptionProcessorInterceptor : ExceptionProcessorInterceptor<Oracle
     
 public static class ExceptionProcessorExtensions
 {
+    public static IServiceCollection AddExceptionProcessor(this IServiceCollection services, ServiceLifetime serviceLifetime = ServiceLifetime.Scoped)
+    {
+        services.Add(ServiceDescriptor.Describe(typeof(IInterceptor), typeof(OracleExceptionProcessorInterceptor), serviceLifetime));
+        return services;
+    }
+
     public static DbContextOptionsBuilder UseExceptionProcessor(this DbContextOptionsBuilder self)
     {
         return self.AddInterceptors(new OracleExceptionProcessorInterceptor());

--- a/EntityFramework.Exceptions.PostgreSQL/PostgreSQL.csproj
+++ b/EntityFramework.Exceptions.PostgreSQL/PostgreSQL.csproj
@@ -14,4 +14,11 @@
   <ItemGroup>
     <PackageReference Update="Microsoft.SourceLink.GitHub" Version="1.1.1" />
   </ItemGroup>
+
+
+	<ItemGroup>
+		<AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+			<_Parameter1>$(SolutionName).Tests</_Parameter1>
+		</AssemblyAttribute>
+	</ItemGroup>
 </Project>

--- a/EntityFramework.Exceptions.PostgreSQL/PostgresExceptionProcessorInterceptor.cs
+++ b/EntityFramework.Exceptions.PostgreSQL/PostgresExceptionProcessorInterceptor.cs
@@ -1,5 +1,7 @@
 ﻿using EntityFramework.Exceptions.Common;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.Extensions.DependencyInjection;
 using Npgsql;
 
 namespace EntityFramework.Exceptions.PostgreSQL;
@@ -22,6 +24,12 @@ class PostgresExceptionProcessorInterceptor : ExceptionProcessorInterceptor<Post
 
 public static class ExceptionProcessorExtensions
 {
+    public static IServiceCollection AddExceptionProcessor(this IServiceCollection services, ServiceLifetime serviceLifetime = ServiceLifetime.Scoped)
+	{
+        services.Add(ServiceDescriptor.Describe(typeof(IInterceptor), typeof(PostgresExceptionProcessorInterceptor), serviceLifetime));
+        return services;
+    }
+
     public static DbContextOptionsBuilder UseExceptionProcessor(this DbContextOptionsBuilder self)
     {
         return self.AddInterceptors(new PostgresExceptionProcessorInterceptor());

--- a/EntityFramework.Exceptions.SqlServer/SqlServer.csproj
+++ b/EntityFramework.Exceptions.SqlServer/SqlServer.csproj
@@ -14,4 +14,10 @@
   <ItemGroup>
     <PackageReference Update="Microsoft.SourceLink.GitHub" Version="1.1.1" />
   </ItemGroup>
+
+	<ItemGroup>
+		<AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+			<_Parameter1>$(SolutionName).Tests</_Parameter1>
+		</AssemblyAttribute>
+	</ItemGroup>
 </Project>

--- a/EntityFramework.Exceptions.SqlServer/SqlServerExceptionProcessorInterceptor.cs
+++ b/EntityFramework.Exceptions.SqlServer/SqlServerExceptionProcessorInterceptor.cs
@@ -1,6 +1,8 @@
 ﻿using EntityFramework.Exceptions.Common;
 using Microsoft.Data.SqlClient;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace EntityFramework.Exceptions.SqlServer;
 
@@ -30,6 +32,12 @@ class SqlServerExceptionProcessorInterceptor: ExceptionProcessorInterceptor<SqlE
 
 public static class ExceptionProcessorExtensions
 {
+    public static IServiceCollection AddExceptionProcessor(this IServiceCollection services, ServiceLifetime serviceLifetime = ServiceLifetime.Scoped)
+    {
+        services.Add(ServiceDescriptor.Describe(typeof(IInterceptor), typeof(SqlServerExceptionProcessorInterceptor), serviceLifetime));
+        return services;
+    }
+
     public static DbContextOptionsBuilder UseExceptionProcessor(this DbContextOptionsBuilder self)
     {
         return self.AddInterceptors(new SqlServerExceptionProcessorInterceptor());

--- a/EntityFramework.Exceptions.Sqlite/Sqlite.csproj
+++ b/EntityFramework.Exceptions.Sqlite/Sqlite.csproj
@@ -14,4 +14,10 @@
   <ItemGroup>
     <PackageReference Update="Microsoft.SourceLink.GitHub" Version="1.1.1" />
   </ItemGroup>
+
+	<ItemGroup>
+		<AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+			<_Parameter1>$(SolutionName).Tests</_Parameter1>
+		</AssemblyAttribute>
+	</ItemGroup>
 </Project>

--- a/EntityFramework.Exceptions.Sqlite/SqliteExceptionProcessorInterceptor.cs
+++ b/EntityFramework.Exceptions.Sqlite/SqliteExceptionProcessorInterceptor.cs
@@ -1,6 +1,8 @@
 ﻿using EntityFramework.Exceptions.Common;
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.Extensions.DependencyInjection;
 using static SQLitePCL.raw;
 
 namespace EntityFramework.Exceptions.Sqlite;
@@ -28,6 +30,12 @@ class SqliteExceptionProcessorInterceptor : ExceptionProcessorInterceptor<Sqlite
 
 public static class ExceptionProcessorExtensions
 {
+    public static IServiceCollection AddExceptionProcessor(this IServiceCollection services, ServiceLifetime serviceLifetime = ServiceLifetime.Scoped)
+    {
+        services.Add(ServiceDescriptor.Describe(typeof(IInterceptor), typeof(SqliteExceptionProcessorInterceptor), serviceLifetime));
+        return services;
+    }
+
     public static DbContextOptionsBuilder UseExceptionProcessor(this DbContextOptionsBuilder self)
     {
         return self.AddInterceptors(new SqliteExceptionProcessorInterceptor());

--- a/EntityFramework.Exceptions.Tests/DatabaseTests.cs
+++ b/EntityFramework.Exceptions.Tests/DatabaseTests.cs
@@ -100,7 +100,7 @@ public abstract class DatabaseTests : IDisposable
     public virtual async Task DeleteParentItemThrowsReferenceConstraintException()
     {
         var product = new Product { Name = "AN" };
-        var productPriceHistory = new ProductPriceHistory { Product = product, Price = 15.27m, EffectiveDate = DateTimeOffset.UtcNow.Date.AddDays(-10) };
+        var productPriceHistory = new ProductPriceHistory { Product = product, Price = 15.27m, EffectiveDate = DateTime.UtcNow.Date.AddDays(-10) };
         Context.ProductPriceHistories.Add(productPriceHistory);
         await Context.SaveChangesAsync();
 

--- a/EntityFramework.Exceptions.Tests/MySqlServerPomeloTests .cs
+++ b/EntityFramework.Exceptions.Tests/MySqlServerPomeloTests .cs
@@ -1,16 +1,30 @@
 ﻿using EntityFramework.Exceptions.MySQL.Pomelo;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
 namespace EntityFramework.Exceptions.Tests;
 
 [Collection("MySQL Test Collection")]
-class MySQLServerPomeloTests : DatabaseTests, IClassFixture<MySQLDemoContextPomeloFixture>
+public class MySQLServerPomeloTests : DatabaseTests, IClassFixture<MySQLDemoContextPomeloFixture>
 {
     public MySQLServerPomeloTests(MySQLDemoContextPomeloFixture fixture) : base(fixture.Context)
     {
 
+    }
+
+    [Fact]
+    public void DependencyInjectionInterceptorTest()
+    {
+        using var services = new ServiceCollection()
+            .AddExceptionProcessor()
+            .BuildServiceProvider()
+        ;
+
+        var interceptor = services.GetRequiredService<IInterceptor>();
+        Assert.IsType<MySqlExceptionProcessorInterceptor>(interceptor);
     }
 }
 

--- a/EntityFramework.Exceptions.Tests/MySqlServerTests.cs
+++ b/EntityFramework.Exceptions.Tests/MySqlServerTests.cs
@@ -1,6 +1,8 @@
 ﻿using EntityFramework.Exceptions.MySQL;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
 namespace EntityFramework.Exceptions.Tests;
@@ -11,6 +13,18 @@ public class MySQLServerTests : DatabaseTests, IClassFixture<MySQLDemoContextFix
     public MySQLServerTests(MySQLDemoContextFixture fixture) : base(fixture.Context)
     {
 
+    }
+
+    [Fact]
+    public void DependencyInjectionInterceptorTest()
+    {
+        using var services = new ServiceCollection()
+            .AddExceptionProcessor()
+            .BuildServiceProvider()
+        ;
+
+        var interceptor = services.GetRequiredService<IInterceptor>();
+        Assert.IsType<MySqlExceptionProcessorInterceptor>(interceptor);
     }
 }
 

--- a/EntityFramework.Exceptions.Tests/OracleTests.cs
+++ b/EntityFramework.Exceptions.Tests/OracleTests.cs
@@ -3,6 +3,8 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using EntityFramework.Exceptions.Oracle;
 using Xunit;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace EntityFramework.Exceptions.Tests;
 
@@ -10,6 +12,18 @@ public class OracleTests : DatabaseTests, IClassFixture<OracleTestContextFixture
 {
     public OracleTests(OracleTestContextFixture fixture) : base(fixture.Context)
     {
+    }
+
+    [Fact]
+    public void DependencyInjectionInterceptorTest()
+    {
+        using var services = new ServiceCollection()
+            .AddExceptionProcessor()
+            .BuildServiceProvider()
+        ;
+
+        var interceptor = services.GetRequiredService<IInterceptor>();
+        Assert.IsType<OracleExceptionProcessorInterceptor>(interceptor);
     }
 }
 

--- a/EntityFramework.Exceptions.Tests/PostgreSQLTests.cs
+++ b/EntityFramework.Exceptions.Tests/PostgreSQLTests.cs
@@ -1,6 +1,8 @@
 ﻿using EntityFramework.Exceptions.PostgreSQL;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
 using System;
 using Xunit;
 
@@ -10,6 +12,18 @@ namespace EntityFramework.Exceptions.Tests
     {
         public PostgreSQLTests(PostgreSQLDemoContextFixture fixture) : base(fixture.Context)
         {
+        }
+
+        [Fact]
+        public void DependencyInjectionInterceptorTest()
+        {
+            using var services = new ServiceCollection()
+                .AddExceptionProcessor()
+                .BuildServiceProvider()
+            ;
+
+            var interceptor = services.GetRequiredService<IInterceptor>();
+            Assert.IsType<PostgresExceptionProcessorInterceptor>(interceptor);
         }
     }
 

--- a/EntityFramework.Exceptions.Tests/SqlServerTests.cs
+++ b/EntityFramework.Exceptions.Tests/SqlServerTests.cs
@@ -1,6 +1,8 @@
 ﻿using EntityFramework.Exceptions.SqlServer;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
 using System;
 using System.Threading.Tasks;
 using Xunit;
@@ -30,6 +32,18 @@ public class SqlServerTests : DatabaseTests, IClassFixture<SqlServerDemoContextF
     public override Task NumericOverflowViolationThrowsNumericOverflowException()
     {
         return Task.CompletedTask;
+    }
+
+    [Fact]
+    public void DependencyInjectionInterceptorTest()
+    {
+        using var services = new ServiceCollection()
+            .AddExceptionProcessor()
+            .BuildServiceProvider()
+        ;
+
+        var interceptor = services.GetRequiredService<IInterceptor>();
+        Assert.IsType<SqlServerExceptionProcessorInterceptor>(interceptor);
     }
 }
 

--- a/EntityFramework.Exceptions.Tests/SqliteTests.cs
+++ b/EntityFramework.Exceptions.Tests/SqliteTests.cs
@@ -1,7 +1,9 @@
 ﻿using EntityFramework.Exceptions.Sqlite;
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
 using SQLitePCL;
 using System;
 using System.Runtime.InteropServices;
@@ -40,6 +42,18 @@ namespace EntityFramework.Exceptions.Tests
         public override Task NumericOverflowViolationThrowsNumericOverflowException()
         {
             return Task.CompletedTask;
+        }
+
+        [Fact]
+        public void DependencyInjectionInterceptorTest()
+        {
+            using var services = new ServiceCollection()
+                .AddExceptionProcessor()
+                .BuildServiceProvider()
+            ;
+
+            var interceptor = services.GetRequiredService<IInterceptor>();
+            Assert.IsType<SqliteExceptionProcessorInterceptor>(interceptor);
         }
     }
 


### PR DESCRIPTION
In some cases where there is no possibility to use `DbContextOptionsBuilder` this extension adds an ability to use `IServiceCollection` to add `ExceptionProcessorInterceptor` to a list of services with a service type of `IInterceptor`.
Later this could be used to add interceptors where appropriate using `IServiceProvider`.

For example.
Our project uses this to setup a Db context:
```c#
services
    .AddDbContext<MedServiceDbContext>((srv, opts) => opts
        .AddInterceptors(srv.GetServices<IInterceptor>())
        .UseNpgsql(configuration.GetMedServiceDbConnectionString()))
;
```
And there is no way to alter this behavior or subclass a `MedServiceDbContext` to change it's `OnConfiguring`.
This PR adds a helper method to cases like this without hurting any backward compatibility.

To use it simply call `AddExceptionProcessor` on a `IServiceCollection` like usual (i.e. `services.AddExceptionProcessor` somewhere in `ConfigureServices` or elsewhere where appropriate) and then when configuring a `DbContext` use the code like above.