### PR TITLE
2022=09-02 - johnavery - Added support for throwing a MaxLengthExceed…

### DIFF
--- a/EntityFramework.Exceptions.SqlServer/SqlServerExceptionProcessorInterceptor.cs
+++ b/EntityFramework.Exceptions.SqlServer/SqlServerExceptionProcessorInterceptor.cs
@@ -12,6 +12,7 @@ class SqlServerExceptionProcessorInterceptor: ExceptionProcessorInterceptor<SqlE
     private const int CannotInsertDuplicateKeyUniqueConstraint = 2627;
     private const int ArithmeticOverflow = 8115;
     private const int StringOrBinaryDataWouldBeTruncated = 8152;
+    private const int StringOrBinaryDataWouldBeTruncated2019 = 2628;
 
     protected override DatabaseError? GetDatabaseError(SqlException dbException)
     {
@@ -23,6 +24,7 @@ class SqlServerExceptionProcessorInterceptor: ExceptionProcessorInterceptor<SqlE
             CannotInsertDuplicateKeyUniqueConstraint => DatabaseError.UniqueConstraint,
             ArithmeticOverflow => DatabaseError.NumericOverflow,
             StringOrBinaryDataWouldBeTruncated => DatabaseError.MaxLength,
+            StringOrBinaryDataWouldBeTruncated2019 => DatabaseError.MaxLength,
             _ => null
         };
     }


### PR DESCRIPTION
…edException from SQL Server 2019's new error code 2628 (see: https://docs.microsoft.com/en-us/archive/blogs/sql_server_team/string-or-binary-data-would-be-truncated-replacing-the-infamous-error-8152)

Fixes issue [#52: MaxLengthExceededException not being thrown when using SQL Server 2019](https://github.com/Giorgi/EntityFramework.Exceptions/issues/52) 