### PR TITLE
Replace <PackageLicenseFile> with <PackageLicenseExpression>

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -19,7 +19,7 @@
     <PackageId>EntityFrameworkCore.Exceptions.$(MSBuildProjectName)</PackageId>
     <PackageIcon>Icon.png</PackageIcon>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <PackageLicenseFile>License.md</PackageLicenseFile>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageReleaseNotes>Add ConstraintName, ConstraintProperties and SchemaQualifiedTableName to UniqueConstraintException and ReferenceConstraintException</PackageReleaseNotes>
     


### PR DESCRIPTION
Because an embedded license file is used instead of an SPDX tag, automated tools like [nuget-license](https://github.com/tomchavakis/nuget-license) and [packageguard](https://github.com/dennisdoomen/packageguard) are unable to detect this package's license. Also the license does not show up in the package's metadata in nuget.

The `License.md` file can still remain in the package, just the metadata would change.

